### PR TITLE
removed notice when session already started

### DIFF
--- a/index.php
+++ b/index.php
@@ -131,7 +131,8 @@ class OneFileLoginApplication
      */
     private function doStartSession()
     {
-        session_start();
+        if(session_status() == PHP_SESSION_NONE) session_start();
+        // otherwise, an annoying notice will be thrown if the session is already started
     }
 
     /**


### PR DESCRIPTION
Now it starts session only if it didn't previously, avoiding an annoying notice which say the session was already started.

 Sorry for my last commit, i copied a wrong code. The exits are useful, if you don't want to put an entire website in showPageLoggedIn(). 
Bye